### PR TITLE
Add provision pie charts and dark mode feature.

### DIFF
--- a/static/darkMode.css
+++ b/static/darkMode.css
@@ -1,0 +1,61 @@
+/*Created by Kayla L. Patterson on 07/28/20
+Description: Styling for toggle switch for
+Dark Mode*/
+
+.theme-switch-wrapper {
+  display: flex;
+  align-items: center;
+
+  em {
+    margin-left: 10px;
+    font-size: 1rem;
+  }
+}
+.theme-switch {
+  display: inline-block;
+  height: 34px;
+  position: relative;
+  width: 60px;
+}
+
+.theme-switch input {
+  display:none;
+}
+
+.slider {
+  background-color: #ccc;
+  bottom: 0;
+  cursor: pointer;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  transition: .4s;
+}
+
+.slider:before {
+  background-color: #fff;
+  bottom: 4px;
+  content: "";
+  height: 26px;
+  left: 4px;
+  position: absolute;
+  transition: .4s;
+  width: 26px;
+}
+
+input:checked + .slider {
+  background-color: #66bb6a;
+}
+
+input:checked + .slider:before {
+  transform: translateX(26px);
+}
+
+.slider.round {
+  border-radius: 34px;
+}
+
+.slider.round:before {
+  border-radius: 50%;
+}

--- a/static/darkMode.js
+++ b/static/darkMode.js
@@ -1,0 +1,41 @@
+/*Created by Kayla L. Patterson on 07/28/20
+Description: Creates a dark mode feature when toggle button is 
+clicked on. Used DarkMode.js library to implement this feature.*/
+
+const options = {
+  bottom: '64px', // default: '32px'
+  left: 'unset', // default: '32px'
+  right: '32px', // default: 'unset'
+  time: '0.3s', // default: '0.3s'
+  mixColor: '#fff', // default: '#fff'
+  backgroundColor: '#fff',  // default: '#fff'
+  buttonColorDark: '#100f2c',  // default: '#100f2c'
+  buttonColorLight: '#fff', // default: '#fff'
+  saveInCookies: false, // default: true,
+  label: '', // default: ''
+  autoMatchOsTheme: true // default: true
+}
+
+const darkmode =  new Darkmode();
+
+// When toggle switch is clicked on 
+const toggleSwitch = document.querySelector('.theme-switch input[type="checkbox"]');
+toggleSwitch.addEventListener('change', switchTheme, false);
+
+function switchTheme(e) {
+    //Dark Mode 
+    if (e.target.checked) {
+        document.documentElement.setAttribute('data-theme', 'dark');
+        darkmode.toggle(); 
+        console.log(darkmode.isActivated()) // will return true
+        localStorage.setItem('theme', 'dark'); //stores dark mode in memory 
+    }
+    //Light Mode 
+    else {
+        document.documentElement.setAttribute('data-theme', 'light');
+        darkmode.toggle(); 
+        console.log(!darkmode.isActivated()) // will return false
+        localStorage.setItem('theme', 'light'); //stores light mode in memory 
+    }    
+}
+

--- a/static/metricStyle.css
+++ b/static/metricStyle.css
@@ -21,3 +21,7 @@
     display: block;
 }
 
+canvas {
+    margin-left: 8em; 
+}
+

--- a/static/pieScript.js
+++ b/static/pieScript.js
@@ -2,8 +2,8 @@
 Description: Creates the Provision and Recall 
 Pie Charts, and populates them from data on the backend*/
 
-//Provision Pie Chart 
-new Chart(document.getElementById("provision-chart"), {
+//Precision Pie Chart 
+new Chart(document.getElementById("precision-chart"), {
     type: 'pie',
     data: {
       labels: ["Should of had Access", "Should Not of had Access"],
@@ -15,7 +15,7 @@ new Chart(document.getElementById("provision-chart"), {
     options: {
       title: {
         display: true,
-        text: 'Provision Resource Chart'
+        text: 'Precision Resource Chart'
       }
     }
 });

--- a/static/pieScript.js
+++ b/static/pieScript.js
@@ -1,0 +1,39 @@
+/*Created by Kayla L. Patterson on 07/27/20
+Description: Creates the Provision and Recall 
+Pie Charts, and populates them from data on the backend*/
+
+//Provision Pie Chart 
+new Chart(document.getElementById("provision-chart"), {
+    type: 'pie',
+    data: {
+      labels: ["Should of had Access", "Should Not of had Access"],
+      datasets: [{
+        backgroundColor: ["#3e95cd", "#8e5ea2"],
+        data: [2478,5267] //mock data 
+      }]
+    },
+    options: {
+      title: {
+        display: true,
+        text: 'Provision Resource Chart'
+      }
+    }
+});
+
+//Recall Pie Chart 
+new Chart(document.getElementById("recall-chart"), {
+    type: 'pie',
+    data: {
+      labels: ["Users who got Access", "Users who should of had Access but did not"],
+      datasets: [{
+        backgroundColor: ["#e8c3b9","#c45850"],
+        data: [60,360] //mock data 
+      }]
+    },
+    options: {
+      title: {
+        display: true,
+        text: 'Recall Resource Chart'
+      }
+    }
+});

--- a/templates/hierachyTree.html
+++ b/templates/hierachyTree.html
@@ -6,11 +6,20 @@ HTML file for displaying tree hierarchy-->
         <meta charset="UTF-8">
         <title>User Hierachy Tree</title>
         <link rel="stylesheet" href="{{ url_for('static', filename='tree-style.css') }}"> 
+        <link rel="stylesheet" href="{{ url_for('static', filename='darkMode.css') }}"> 
     </head>
     <body>
         <!--Side Bar with input form-->
         <div class="sidenav">
             <h1>User Hierarchy Tree</h1>
+            <!--Dark Mode Toggle-->
+            <em>Enable Dark Mode!</em>
+            <div class="theme-switch-wrapper">
+                <label class="theme-switch" for="checkbox">
+                    <input type="checkbox" id="checkbox" />
+                    <div class="slider round"></div>
+                </label>
+            </div><br><br>
             <form>
                 <label for="user_1">Enter User_1:</label><br>
                 <input type="text" id="user_1" name="user_1"><br>
@@ -18,6 +27,8 @@ HTML file for displaying tree hierarchy-->
                 <input type="text" id="user_2" name="user_2"><br><br>
                 <input type="submit" value="Calculate Distance">
             </form>
+            <h2>Distance: </h2> 
+            <h2>Similarity: </h2>
             <a href="index.html">Go Back</a>
         </div>
         <!--svg of tree hierarchy layout-->
@@ -25,6 +36,10 @@ HTML file for displaying tree hierarchy-->
 
         <!-- load the d3.js library --> 
         <script src="https://d3js.org/d3.v4.min.js"></script>
+        <!-- tree-script.js file -->
         <script src="{{url_for('static', filename='tree-script.js')}}"></script>
+        <!--Dark Mode -->
+        <script src="https://cdn.jsdelivr.net/npm/darkmode-js@1.5.6/lib/darkmode-js.min.js"></script>
+        <script src="{{url_for('static', filename='darkMode.js')}}"></script>  
     </body>
 </html 

--- a/templates/provisionMetrics.html
+++ b/templates/provisionMetrics.html
@@ -1,16 +1,45 @@
 <!DOCTYPE html> 
 <head> 
     <meta charset="UTF-8">
-    <link rel="stylesheet" href="{{ url_for('static', filename='metrics-style.css') }}"> 
+    <link rel="stylesheet" href="{{ url_for('static', filename='metrics-style.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='darkMode.css') }}">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.min.js"></script>
 </head> 
 <body> 
     <!-- Side Navigation --> 
     <div class="sidenav">
-	<h1>Provisioning Metrics</h1>
-	<form> 
-	    <a href="index.html">Go Back</a> 	    
-	</form> 
+	    <h1>Provisioning Metrics</h1>
+        <!--Dark Mode toggle button --> 
+        <em>Enable Dark Mode!</em>
+            <div class="theme-switch-wrapper">
+                <label class="theme-switch" for="checkbox">
+                    <input type="checkbox" id="checkbox" />
+                    <div class="slider round"></div>
+                </label>
+        </div><br><br>
+        <!--User Input -->
+	    <form>
+            <label for="resource_1">Enter Resource:</label><br>
+            <input type="text" id="resource_id_1" name="id_1"><br>
+            <input type="text" id="resource_id_2" name="id_2"><br><br>
+            <button type="button" id="btnsearchPath" style="font-size: 18px;">Calculate</button> 	    
+	    </form>
+        <h4>Provisioning Calulcations:</h4>
+        <h4>Recall Calculations:</h4> 
+
+        <a href="index.html">Go Back</a> 
     </div> 
+    
+    <!-- Pie Charts --> 
+    <canvas id="provision-chart" width="900" height="300"></canvas>
+    <canvas id="recall-chart" width="900" height="300"></canvas>
+   
+    <! --pie-script.js file-->
+    <script src="{{url_for('static', filename='pie-script.js')}}"></script>    
+    <!--Dark Mode -->
+    <script src="https://cdn.jsdelivr.net/npm/darkmode-js@1.5.6/lib/darkmode-js.min.js"></script>
+    <script src="{{url_for('static', filename='darkMode.js')}}"></script>
 </body> 
 
 </html>

--- a/templates/provisionMetrics.html
+++ b/templates/provisionMetrics.html
@@ -25,14 +25,20 @@
             <input type="text" id="resource_id_2" name="id_2"><br><br>
             <button type="button" id="btnsearchPath" style="font-size: 18px;">Calculate</button> 	    
 	    </form>
-        <h4>Provisioning Calulcations:</h4>
-        <h4>Recall Calculations:</h4> 
+        <h4>Precision:</h4>
+        <h4>Recall:</h4><br><br>
+        <form>
+            <label for="resource_1">Enter Resource:</label><br>
+            <input type="text" id="resource_id_1" name="id_1"><br>
+            <input type="text" id="resource_id_2" name="id_2"><br><br>
+            <button type="button" id="btnsearchPath" style="font-size: 18px;">Find Rule</button>
+        </form><br><br>
 
         <a href="index.html">Go Back</a> 
     </div> 
     
     <!-- Pie Charts --> 
-    <canvas id="provision-chart" width="900" height="300"></canvas>
+    <canvas id="precision-chart" width="900" height="300"></canvas>
     <canvas id="recall-chart" width="900" height="300"></canvas>
    
     <! --pie-script.js file-->

--- a/templates/provisionMetrics.html
+++ b/templates/provisionMetrics.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html> 
 <head> 
     <meta charset="UTF-8">
-    <link rel="stylesheet" href="{{ url_for('static', filename='metrics-style.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='metricStyle.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='darkMode.css') }}">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.5.0/Chart.min.js"></script>
@@ -36,7 +36,7 @@
     <canvas id="recall-chart" width="900" height="300"></canvas>
    
     <! --pie-script.js file-->
-    <script src="{{url_for('static', filename='pie-script.js')}}"></script>    
+    <script src="{{url_for('static', filename='pieScript.js')}}"></script>    
     <!--Dark Mode -->
     <script src="https://cdn.jsdelivr.net/npm/darkmode-js@1.5.6/lib/darkmode-js.min.js"></script>
     <script src="{{url_for('static', filename='darkMode.js')}}"></script>


### PR DESCRIPTION
Currently, there was no provisioning pie charts. This change displays two pie charts called Precision and Recall which is currently being populated by mock data (Need to extract data from backend, from any resource that is inputted). The two pie charts are created using the [chart.js](https://www.chartjs.org/) API. A form has also been created in order for users to enter in a resource. Both of the tools also now have a **dark mode feature**. When user clicks on toggle button they can switch between dark mode and light mode. Dark mode feature was created using the [darkmode.js](https://darkmodejs.learn.uno/) library. 

Pie Charts 
![image](https://user-images.githubusercontent.com/41876222/88670078-a3dac100-d0b2-11ea-9578-a020696fbc5c.png)

Dark Mode Feature with Pie Charts 
![image](https://user-images.githubusercontent.com/41876222/88670137-b523cd80-d0b2-11ea-8205-f0654183739f.png)

Dark Mode Feature with Tree 
![image](https://user-images.githubusercontent.com/41876222/88670961-b7d2f280-d0b3-11ea-94bd-32f500938c15.png)
