### PR TITLE
Changed display of navigation bar.

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -22,7 +22,7 @@ nav {
 .nav-links {
 	display: flex;
 	justify-content: space-around;
-	width: 30%;
+	width: 20%;
 }
 
 nav li {

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,7 +11,7 @@
 			<div class="logo">
 				<h4>SAM: Google STEP Capstone 2020</h4>
 			</div>
-			<ul>
+			<ul class="nav-links">
 				<li><a href="research.html">Mission</a></li>
 				<li><a href="research.html">Research</a></li>
 				<li><a href="research.html">The Team</a></li>


### PR DESCRIPTION
Currently, the links on the left side of the navigation bar were stack on top of each other. This modification has the links side by side rather than stack on top.

Before
![image](https://user-images.githubusercontent.com/41876222/88957547-011a7200-d26d-11ea-83b6-5cf216342260.png)

Now
![image](https://user-images.githubusercontent.com/41876222/88957480-eba54800-d26c-11ea-8e47-e0fdb8190d29.png)
